### PR TITLE
Silly fix on django imports

### DIFF
--- a/MySQLdb/constants/FLAG.py
+++ b/MySQLdb/constants/FLAG.py
@@ -1,0 +1,1 @@
+from flags import *


### PR DESCRIPTION
Django try to import constants.FLAG which is flags.py in mysql-ctypes.
Just a silly fix, I just created a FLAG.py and inside it from flags import *.
