### PR TITLE
Support for LONGBLOB columns

### DIFF
--- a/MySQLdb/converters.py
+++ b/MySQLdb/converters.py
@@ -87,6 +87,7 @@ _simple_field_decoders = {
     field_types.DECIMAL: Decimal,
     field_types.NEWDECIMAL: Decimal,
 
+    field_types.LONG_BLOB: str,
     field_types.BLOB: str,
     field_types.VAR_STRING: str,
     field_types.STRING: str,

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -123,6 +123,31 @@ class TestCursor(BaseMySQLTests):
                 assert val == "".join(chr(x) for x in xrange(255))
                 assert type(val) is str
 
+    def test_geometry_point(self, connection):
+        x, y = 15, 20
+
+        with self.create_table(connection, "coordinates", point="POINT"):
+            with contextlib.closing(connection.cursor()) as cur:
+                cur.execute("INSERT INTO coordinates (point) VALUES (Point(%s, %s))", (x, y))
+                cur.execute("SELECT AsText(point) FROM coordinates")
+                row, = cur.fetchall()
+                val, = row
+
+                assert val == "POINT(%d %d)" % (x, y) # Well formed WKT
+                assert type(val) is str
+
+    def test_geometry_linestring(self, connection):
+        coordinates = ([0, 0], [10, 10], [20, 25], [50, 60])
+        linestring = 'LINESTRING(%s)' % ', '.join([('%f %f' % (x[0], x[1])) for x in coordinates])
+        with self.create_table(connection, "coordinates", line="LINESTRING"):
+            with contextlib.closing(connection.cursor()) as cur:
+                cur.execute("INSERT INTO coordinates (line) VALUES (GeomFromText(%s))", (linestring,))
+                cur.execute("SELECT AsText(line) FROM coordinates")
+                row, = cur.fetchall()
+                val, = row
+
+                assert type(val) is str
+
     def test_nonexistant_table(self, connection):
         with contextlib.closing(connection.cursor()) as cur:
             with py.test.raises(connection.ProgrammingError) as cm:


### PR DESCRIPTION
SQL queries like a `SELECT AsText(point) FROM geometry_table` raises an exception `InternalError: No decoder for type 251, value: POINT(15 20)`, where type 251 is _LONGBLOB_ and returned value type is _str_.

This commit adds LONGBLOB fields support.

Some tests for POINT and LINESTRING columns attached.
